### PR TITLE
Magento 2.3 Compatibility Fix

### DIFF
--- a/Model/ResourceModel/Api/Category.php
+++ b/Model/ResourceModel/Api/Category.php
@@ -6,6 +6,7 @@
 
 namespace Emartech\Emarsys\Model\ResourceModel\Api;
 
+use Magento\Catalog\Model\Indexer\Category\Product\Processor;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResourceModel;
 use Magento\Catalog\Model\ResourceModel\Category\TreeFactory;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
@@ -48,6 +49,7 @@ class Category extends CategoryResourceModel
      * @param TreeFactory           $categoryTreeFactory
      * @param CollectionFactory     $categoryCollectionFactory
      * @param Iterator              $iterator
+     * @param Processor             $processor
      * @param array                 $data
      */
     public function __construct(
@@ -58,6 +60,7 @@ class Category extends CategoryResourceModel
         TreeFactory $categoryTreeFactory,
         CollectionFactory $categoryCollectionFactory,
         Iterator $iterator,
+        Processor $processor,
         array $data = []
     ) {
         $this->iterator = $iterator;
@@ -69,6 +72,7 @@ class Category extends CategoryResourceModel
             $eventManager,
             $categoryTreeFactory,
             $categoryCollectionFactory,
+            $processor,
             $data
         );
     }

--- a/Model/ResourceModel/Api/Category.php
+++ b/Model/ResourceModel/Api/Category.php
@@ -7,6 +7,7 @@
 namespace Emartech\Emarsys\Model\ResourceModel\Api;
 
 use Magento\Catalog\Model\Indexer\Category\Product\Processor;
+use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Catalog\Model\ResourceModel\Category as CategoryResourceModel;
 use Magento\Catalog\Model\ResourceModel\Category\TreeFactory;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory;
@@ -42,15 +43,16 @@ class Category extends CategoryResourceModel
     /**
      * Category constructor.
      *
-     * @param Context               $context
-     * @param StoreManagerInterface $storeManager
-     * @param Factory               $modelFactory
-     * @param ManagerInterface      $eventManager
-     * @param TreeFactory           $categoryTreeFactory
-     * @param CollectionFactory     $categoryCollectionFactory
-     * @param Iterator              $iterator
-     * @param Processor             $processor
-     * @param array                 $data
+     * @param Context                   $context
+     * @param StoreManagerInterface     $storeManager
+     * @param Factory                   $modelFactory
+     * @param ManagerInterface          $eventManager
+     * @param TreeFactory               $categoryTreeFactory
+     * @param CollectionFactory         $categoryCollectionFactory
+     * @param Iterator                  $iterator
+     * @param Processor                 $processor
+     * @param ProductMetadataInterface  $productMetadata
+     * @param array                     $data
      */
     public function __construct(
         Context $context,
@@ -61,20 +63,33 @@ class Category extends CategoryResourceModel
         CollectionFactory $categoryCollectionFactory,
         Iterator $iterator,
         Processor $processor,
+        ProductMetadataInterface $productMetadata,
         array $data = []
     ) {
         $this->iterator = $iterator;
 
-        parent::__construct(
-            $context,
-            $storeManager,
-            $modelFactory,
-            $eventManager,
-            $categoryTreeFactory,
-            $categoryCollectionFactory,
-            $processor,
-            $data
-        );
+        if (version_compare($productMetadata->getVersion(), '2.3.0', '>=')) {
+            parent::__construct(
+                $context,
+                $storeManager,
+                $modelFactory,
+                $eventManager,
+                $categoryTreeFactory,
+                $categoryCollectionFactory,
+                $processor,
+                $data
+            );
+        } else {
+            parent::__construct(
+                $context,
+                $storeManager,
+                $modelFactory,
+                $eventManager,
+                $categoryTreeFactory,
+                $categoryCollectionFactory,
+                $data
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
- Added required parameter to the parent construct method in `Model/ResourceModel/Api/Category.php` for `Magento\Catalog\Model\ResourceModel\Category` construct parameter changes in 2.3

- Added version check for 2.3.0 or greater, code defaults to the old parent construct if using version 2.2 or earlier.