### PR TITLE
Skip sending customer's null values

### DIFF
--- a/Helper/CustomerEventHandler.php
+++ b/Helper/CustomerEventHandler.php
@@ -93,6 +93,7 @@ class CustomerEventHandler extends BaseEventHandler
         }
 
         $customerData = $this->customerHelper->getOneCustomer($customerId, $websiteId, true);
+        $customerData = $this->cleanEmptyCustomerData($customerData);
 
         if (false !== $customerData) {
             $this->saveEvent(
@@ -131,5 +132,32 @@ class CustomerEventHandler extends BaseEventHandler
         );
 
         return true;
+    }
+
+    private function cleanEmptyCustomerData($customerData): array
+    {
+        $customerData = $this->cleanEmptyValues($customerData);
+        $keysToClean = [\Emartech\Emarsys\Api\Data\CustomerInterface::BILLING_ADDRESS_KEY, \Emartech\Emarsys\Api\Data\CustomerInterface::SHIPPING_ADDRESS_KEY];
+        foreach($keysToClean as $keyToClean){
+            if(isset($customerData[$keyToClean])){
+                $customerData[$keyToClean] = $this->cleanEmptyValues($customerData[$keyToClean]);
+                if(empty($customerData[$keyToClean])){
+                    unset($customerData[$keyToClean]);
+                }
+            }
+        }
+
+        return $customerData;
+    }
+
+    private function cleanEmptyValues(array $array): array
+    {
+        return array_filter($array, function($value){
+            if ($value === null) {
+                return false;
+            }
+
+            return true;
+        });
     }
 }


### PR DESCRIPTION
This change removes empty values from customers' and customers' addresses to avoid overriding data in Emarsys contacts database. Initial issue reported here: https://github.com/emartech/magento2-extension/issues/22

Customer array before:
![image](https://user-images.githubusercontent.com/511845/163568635-d6885dbe-ff9b-40ae-99f1-e29662c33801.png)

Customer array after:
![image](https://user-images.githubusercontent.com/511845/163568611-932e02d4-07e9-4fa8-9c4a-6c4724614fb0.png)
