### PR TITLE
Fix Error on Customer Login

### DIFF
--- a/Model/ResourceModel/Api/Customer.php
+++ b/Model/ResourceModel/Api/Customer.php
@@ -389,19 +389,21 @@ class Customer extends CustomerResourceModel
         }
 
         try {
-            $unionQuery = $this->_resource->getConnection()->select()
-                ->union(
-                    $attributeQueries,
-                    \Zend_Db_Select::SQL_UNION_ALL
-                ); // @codingStandardsIgnoreLine
-            $this->iterator->walk(
-                (string)$unionQuery,
-                [[$this, 'handleAttributeDataTable']],
-                [
-                    'attributeMapper' => $attributeMapper,
-                ],
-                $this->_resource->getConnection()
-            );
+            if (count($attributeQueries)) {
+                $unionQuery = $this->_resource->getConnection()->select()
+                    ->union(
+                        $attributeQueries,
+                        \Zend_Db_Select::SQL_UNION_ALL
+                    ); // @codingStandardsIgnoreLine
+                $this->iterator->walk(
+                    (string)$unionQuery,
+                    [[$this, 'handleAttributeDataTable']],
+                    [
+                        'attributeMapper' => $attributeMapper,
+                    ],
+                    $this->_resource->getConnection()
+                );
+            }
         } catch (\Exception $e) {} // @codingStandardsIgnoreLine
 
         return $this;


### PR DESCRIPTION
- Error Message: ValueError: PDO::prepare(): Argument #1 ($query) cannot be empty in /var/www/html/vendor/magento/zendframework1/library/Zend/Db/Statement/Pdo.php:58

A similar change was made in this commit: https://github.com/emartech/magento2-extension/commit/afd950d4ba3e69ba46d4273b5e0b6941321ceae6

It references ticket CDP-7567