### PR TITLE
Prevent emulation nesting in DataSource helper

### DIFF
--- a/Helper/DataSource.php
+++ b/Helper/DataSource.php
@@ -48,8 +48,8 @@ class DataSource
             $this->optionValues[$storeId] = [];
             $this->startEmulation($storeId)
                  ->getAllOptionsByStore($sourceModels, $storeId);
+            $this->stopEmulation();
         }
-        $this->stopEmulation();
 
         return $this->optionValues;
     }


### PR DESCRIPTION
This fixes behavior that leads to the environment emulation nesting error in Magento logs.