### PR TITLE
Add check for storeId in SalesEventHandler

### DIFF
--- a/Helper/SalesEventHandler.php
+++ b/Helper/SalesEventHandler.php
@@ -59,6 +59,9 @@ class SalesEventHandler extends BaseEventHandler
     public function store(Order $order): bool
     {
         $storeId = $order->getStoreId();
+        if (!$storeId) {
+            $storeId = $this->storeManager->getStore()->getId();
+        }
 
         if (!$this->isEnabledForStore($storeId)) {
             return false;


### PR DESCRIPTION
This check prevents the storeId from being null, which led to an error when calling saveEvent

This is pretty much the same fix as in isEnabledStore in [Model/Data/Config.php](https://github.com/emartech/magento2-extension/blob/master/Model/Data/Config.php#L327) (lines 327-329)

