### PR TITLE
Added default value for setPostCode in CustomerAddressInterface and C…

### DIFF
--- a/Api/Data/CustomerAddressInterface.php
+++ b/Api/Data/CustomerAddressInterface.php
@@ -189,14 +189,14 @@ interface CustomerAddressInterface
     /**
      * GetPostcode
      *
-     * @return string
+     * @return string|null
      */
-    public function getPostcode(): string;
+    public function getPostcode(): ?string;
 
     /**
      * SetPostcode
      *
-     * @param string $postCode
+     * @param string|null $postCode
      *
      * @return \Emartech\Emarsys\Api\Data\CustomerAddressInterface
      */

--- a/Api/Data/CustomerAddressInterface.php
+++ b/Api/Data/CustomerAddressInterface.php
@@ -200,7 +200,7 @@ interface CustomerAddressInterface
      *
      * @return \Emartech\Emarsys\Api\Data\CustomerAddressInterface
      */
-    public function setPostcode(string $postCode): CustomerAddressInterface;
+    public function setPostcode(string $postCode = null): CustomerAddressInterface;
 
     /**
      * GetTelephone

--- a/Model/Data/CustomerAddress.php
+++ b/Model/Data/CustomerAddress.php
@@ -81,11 +81,11 @@ class CustomerAddress extends DataObject implements CustomerAddressInterface
     /**
      * GetPostcode
      *
-     * @return string
+     * @return string|null
      */
-    public function getPostcode(): string
+    public function getPostcode(): ?string
     {
-        return (string) $this->getData(self::POSTCODE_KEY);
+        return $this->getData(self::POSTCODE_KEY);
     }
 
     /**

--- a/Model/Data/CustomerAddress.php
+++ b/Model/Data/CustomerAddress.php
@@ -253,7 +253,7 @@ class CustomerAddress extends DataObject implements CustomerAddressInterface
      *
      * @return CustomerAddressInterface
      */
-    public function setPostcode(string $postCode): CustomerAddressInterface
+    public function setPostcode(string $postCode = null): CustomerAddressInterface
     {
         $this->setData(self::POSTCODE_KEY, $postCode);
 


### PR DESCRIPTION
…ustomerAddress to prevent error when handleAddressWebsiteData returns null for 'postcode'.

Tested only on a specific instance, where a null postcode was returned here https://github.com/emartech/magento2-extension/blob/570f7288daadee6c5008e705a0121e4fe07a32b7/Helper/Customer.php#L691 causing a persistent error in contacts synchronization.
